### PR TITLE
test(fetch-url): add coverage for isPrivateIP

### DIFF
--- a/netlify/functions/fetch-url.js
+++ b/netlify/functions/fetch-url.js
@@ -1,4 +1,3 @@
-\
 /**
  * Netlify Function: fetch-url
  * Securely fetches HTML for a given URL with basic SSRF protections,
@@ -173,6 +172,9 @@ function isPrivateIP(ip) {
   }
   return false;
 }
+
+// Export for testing
+exports.isPrivateIP = isPrivateIP;
 
 async function robotsAllows(theUrl) {
   try {

--- a/tests/isPrivateIP.test.js
+++ b/tests/isPrivateIP.test.js
@@ -1,0 +1,20 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { isPrivateIP } = require('../netlify/functions/fetch-url.js');
+
+test('detects private IPv4 addresses', () => {
+  assert.strictEqual(isPrivateIP('10.0.0.1'), true);
+  assert.strictEqual(isPrivateIP('172.16.0.1'), true);
+  assert.strictEqual(isPrivateIP('172.31.255.255'), true);
+  assert.strictEqual(isPrivateIP('192.168.1.1'), true);
+  assert.strictEqual(isPrivateIP('127.0.0.1'), true);
+  assert.strictEqual(isPrivateIP('169.254.2.5'), true);
+  assert.strictEqual(isPrivateIP('8.8.8.8'), false);
+});
+
+test('detects private IPv6 addresses', () => {
+  assert.strictEqual(isPrivateIP('::1'), true);
+  assert.strictEqual(isPrivateIP('fe80::1'), true);
+  assert.strictEqual(isPrivateIP('fd00::1234'), true);
+  assert.strictEqual(isPrivateIP('2001:4860:4860::8888'), false);
+});


### PR DESCRIPTION
## Summary
- export `isPrivateIP` from `fetch-url` function
- add unit tests for IPv4 and IPv6 private address detection

## Testing
- `node --test tests/isPrivateIP.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bf07e2d234832b8eca23bee8e5309a