### PR TITLE
Remove stray backslash and add get-schema smoke test

### DIFF
--- a/netlify/functions/get-schema.js
+++ b/netlify/functions/get-schema.js
@@ -1,4 +1,3 @@
-\
 /**
  * Netlify Function: get-schema
  * Calls Gemini to infer a stable CSS selector for sub-page links and the "Next" button text.
@@ -97,7 +96,7 @@ function buildPrompt() {
     '  • The HTML of a main listing/index page.',
     '  • A screenshot of that main page.',
     '  • A screenshot of a typical sub-page/detail page.',
-    '  • A screenshot of the site\\'s pagination NEXT button.',
+    '  • A screenshot of the site\'s pagination NEXT button.',
     '',
     'Task: Infer a robust CSS selector that selects ONLY the link elements on the main page that lead to the sub-pages (detail pages), not navigation, ads, or unrelated links.',
     'Also infer the human-visible text that the site uses for its "Next page" control (e.g., "Next", "Older posts", "›").',

--- a/tests/getSchemaLoad.test.js
+++ b/tests/getSchemaLoad.test.js
@@ -1,0 +1,8 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+const { handler } = require('../netlify/functions/get-schema.js');
+
+test('get-schema handler is defined', () => {
+  assert.strictEqual(typeof handler, 'function');
+});


### PR DESCRIPTION
## Summary
- remove stray leading backslash so `get-schema.js` starts with a comment block
- add basic smoke test ensuring `get-schema` exports a handler

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68bf0bdcb060832bb6373af050b9c104