### PR TITLE
feat: persist scraper sessions using indexeddb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,145 @@
+{
+  "name": "edge-scraper-pro",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "edge-scraper-pro",
+      "version": "1.0.0",
+      "devDependencies": {
+        "fake-indexeddb": "^4.0.2"
+      }
+    },
+    "node_modules/base64-arraybuffer-es6": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.7.0.tgz",
+      "integrity": "sha512-ESyU/U1CFZDJUdr+neHRhNozeCv72Y7Vm0m1DCbjX3KBjT6eYocvAJlSk6+8+HkVwXlT1FNxhGW6q3UKAlCvvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/domexception": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-1.0.1.tgz",
+      "integrity": "sha512-raigMkn7CJNNo6Ihro1fzG7wr3fHuYVytzquZKX5n0yizGsTcYgzdIUwj1X9pK0VvjeihV+XiclP+DjwbsSKug==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webidl-conversions": "^4.0.2"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-4.0.2.tgz",
+      "integrity": "sha512-SdTwEhnakbgazc7W3WUXOJfGmhH0YfG4d+dRPOFoYDRTL6U5t8tvrmkf2W/C3W1jk2ylV7Wrnj44RASqpX/lEw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "realistic-structured-clone": "^3.0.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/realistic-structured-clone": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/realistic-structured-clone/-/realistic-structured-clone-3.0.0.tgz",
+      "integrity": "sha512-rOjh4nuWkAqf9PWu6JVpOWD4ndI+JHfgiZeMmujYcPi+fvILUu7g6l26TC1K5aBIp34nV+jE1cDO75EKOfHC5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "domexception": "^1.0.1",
+        "typeson": "^6.1.0",
+        "typeson-registry": "^1.0.0-alpha.20"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+      "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/typeson": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/typeson/-/typeson-6.1.0.tgz",
+      "integrity": "sha512-6FTtyGr8ldU0pfbvW/eOZrEtEkczHRUtduBnA90Jh9kMPCiFNnXIon3vF41N0S4tV1HHQt4Hk1j4srpESziCaA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
+    "node_modules/typeson-registry": {
+      "version": "1.0.0-alpha.39",
+      "resolved": "https://registry.npmjs.org/typeson-registry/-/typeson-registry-1.0.0-alpha.39.tgz",
+      "integrity": "sha512-NeGDEquhw+yfwNhguLPcZ9Oj0fzbADiX4R0WxvoY8nGhy98IbzQy1sezjoEFWOywOboj/DWehI+/aUlRVrJnnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer-es6": "^0.7.0",
+        "typeson": "^6.0.0",
+        "whatwg-url": "^8.4.0"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.7.0.tgz",
+      "integrity": "sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.7.0",
+        "tr46": "^2.1.0",
+        "webidl-conversions": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/whatwg-url/node_modules/webidl-conversions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-6.1.0.tgz",
+      "integrity": "sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10.4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "edge-scraper-pro",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node --test"
+  },
+  "devDependencies": {
+    "fake-indexeddb": "^4.0.2"
+  }
+}

--- a/public/idb.js
+++ b/public/idb.js
@@ -1,0 +1,178 @@
+(function(global){
+  const DB_NAME = 'scraperState';
+  const DB_VERSION = 1;
+  let db;
+
+  function openDB(){
+    return new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION);
+      request.onupgradeneeded = (event) => {
+        const db = event.target.result;
+        if(!db.objectStoreNames.contains('queue')) db.createObjectStore('queue', { keyPath: 'id', autoIncrement: true });
+        if(!db.objectStoreNames.contains('results')) db.createObjectStore('results', { keyPath: 'id' });
+        if(!db.objectStoreNames.contains('settings')) db.createObjectStore('settings', { keyPath: 'id' });
+        if(!db.objectStoreNames.contains('logs')) db.createObjectStore('logs', { keyPath: 'id', autoIncrement: true });
+      };
+      request.onsuccess = (event) => { db = event.target.result; resolve(); };
+      request.onerror = (event) => reject(event.target.error);
+    });
+  }
+
+  function logTransition(id, from, to){
+    const tx = db.transaction('logs','readwrite');
+    tx.objectStore('logs').add({ ts: Date.now(), id, from, to });
+  }
+
+  async function enqueueUrls(urls){
+    const tx = db.transaction(['queue','logs'],'readwrite');
+    const queue = tx.objectStore('queue');
+    const logs = tx.objectStore('logs');
+    urls.forEach((url, index) => {
+      const req = queue.add({ index, url, status: 'queued', retries: 0 });
+      req.onsuccess = (e) => logs.add({ ts: Date.now(), itemId: e.target.result, from: null, to: 'queued' });
+    });
+    return new Promise((resolve, reject) => {
+      tx.oncomplete = () => resolve();
+      tx.onerror = (e) => reject(e.target.error);
+    });
+  }
+
+  async function getNext(){
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(['queue','logs'],'readwrite');
+      tx.onerror = (e) => reject(e.target.error);
+      const store = tx.objectStore('queue');
+      const logs = tx.objectStore('logs');
+      const req = store.openCursor();
+      req.onerror = (e) => reject(e.target.error);
+      req.onsuccess = (event) => {
+        const cursor = event.target.result;
+        if(!cursor){ resolve(null); return; }
+        const value = cursor.value;
+        if(value.status === 'queued'){
+          const id = value.id;
+          value.status = 'processing';
+          const updateReq = cursor.update(value);
+          logs.add({ ts: Date.now(), itemId: id, from: 'queued', to: 'processing' });
+          updateReq.onsuccess = () => resolve(value);
+        } else {
+          cursor.continue();
+        }
+      };
+    });
+  }
+
+  async function markComplete(id, result){
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(['queue','results','logs'],'readwrite');
+      const queue = tx.objectStore('queue');
+      const results = tx.objectStore('results');
+      const logs = tx.objectStore('logs');
+      queue.get(id).onsuccess = (e) => {
+        const record = e.target.result;
+        const from = record.status;
+        record.status = 'complete';
+        queue.put(record);
+        results.put({ id, ...result });
+        logs.add({ ts: Date.now(), itemId: id, from, to: 'complete' });
+      };
+      tx.oncomplete = () => resolve();
+      tx.onerror = (e) => reject(e.target.error);
+    });
+  }
+
+  async function markFailed(id, error, retryLimit=3){
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(['queue','results','logs'],'readwrite');
+      const queue = tx.objectStore('queue');
+      const results = tx.objectStore('results');
+      const logs = tx.objectStore('logs');
+      queue.get(id).onsuccess = (e) => {
+        const record = e.target.result;
+        const from = record.status;
+        record.retries = (record.retries || 0) + 1;
+        let to = 'failed';
+        if(record.retries < retryLimit){
+          record.status = 'queued';
+          to = 'queued';
+        }else{
+          record.status = 'failed';
+          results.put({ id, ...error });
+        }
+        queue.put(record);
+        logs.add({ ts: Date.now(), itemId: id, from, to });
+      };
+      tx.oncomplete = () => resolve();
+      tx.onerror = (e) => reject(e.target.error);
+    });
+  }
+
+  async function saveSettings(settings){
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction('settings','readwrite');
+      tx.objectStore('settings').put({ id: 'current', ...settings });
+      tx.oncomplete = () => resolve();
+      tx.onerror = (e) => reject(e.target.error);
+    });
+  }
+
+  async function loadState(){
+    const results = await new Promise((resolve, reject) => {
+      const tx = db.transaction('results');
+      const req = tx.objectStore('results').getAll();
+      req.onsuccess = (e) => resolve(e.target.result);
+      req.onerror = (e) => reject(e.target.error);
+    });
+    const settings = await new Promise((resolve, reject) => {
+      const tx = db.transaction('settings');
+      const req = tx.objectStore('settings').get('current');
+      req.onsuccess = (e) => resolve(e.target.result || {});
+      req.onerror = (e) => reject(e.target.error);
+    });
+    const queue = await new Promise((resolve, reject) => {
+      const tx = db.transaction('queue');
+      const req = tx.objectStore('queue').getAll();
+      req.onsuccess = (e) => resolve(e.target.result);
+      req.onerror = (e) => reject(e.target.error);
+    });
+    return { results, settings, queue };
+  }
+
+  async function hasUnfinished(){
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction('queue');
+      const req = tx.objectStore('queue').openCursor();
+      req.onsuccess = (e) => {
+        const cursor = e.target.result;
+        if(!cursor){ resolve(false); return; }
+        const status = cursor.value.status;
+        if(status !== 'complete'){ resolve(true); return; }
+        cursor.continue();
+      };
+      req.onerror = (e) => reject(e.target.error);
+    });
+  }
+
+  async function countQueue(){
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction('queue');
+      const req = tx.objectStore('queue').count();
+      req.onsuccess = (e) => resolve(e.target.result);
+      req.onerror = (e) => reject(e.target.error);
+    });
+  }
+
+  async function clearAll(){
+    if(db) db.close();
+    return new Promise((resolve, reject) => {
+      const req = indexedDB.deleteDatabase(DB_NAME);
+      req.onsuccess = () => { db = undefined; openDB().then(resolve); };
+      req.onerror = (e) => reject(e.target.error);
+    });
+  }
+
+  const ScraperDB = { init: openDB, enqueueUrls, getNext, markComplete, markFailed, saveSettings, loadState, hasUnfinished, countQueue, clearAll };
+  ScraperDB.close = () => { if(db) db.close(); };
+  if(typeof module !== 'undefined') module.exports = ScraperDB;
+  global.ScraperDB = ScraperDB;
+})(typeof self !== 'undefined' ? self : global);

--- a/public/index.html
+++ b/public/index.html
@@ -112,6 +112,11 @@
     </style>
 </head>
 <body>
+    <div id="resumeBanner" class="hidden" style="border:1px solid #000;padding:0.5em;margin-bottom:1em;background:#ff0;">
+        <span>Unfinished session detected.</span>
+        <button id="continueBtn">Continue</button>
+        <button id="restartBtn">Restart</button>
+    </div>
     <div class="container">
         <h1>AI Web Scraper</h1>
         <p>A tool to visually teach an AI to scrape websites. Built for function over form.</p>
@@ -182,6 +187,7 @@
         </div>
     </div>
 
+    <script src="idb.js"></script>
     <script>
         const dom = {
             schemaModeBtn: document.getElementById('schemaModeBtn'),
@@ -214,6 +220,9 @@
             resumeBtn: document.getElementById('resumeBtn'),
             stopBtn: document.getElementById('stopBtn'),
             includeHtmlToggle: document.getElementById('includeHtmlToggle'),
+            resumeBanner: document.getElementById('resumeBanner'),
+            continueBtn: document.getElementById('continueBtn'),
+            restartBtn: document.getElementById('restartBtn'),
         };
 
         let state = {
@@ -221,6 +230,11 @@
             scrapeResults: [],
             runControls: { paused: false, aborted: false }
         };
+
+        (async () => {
+            await ScraperDB.init();
+            if (await ScraperDB.hasUnfinished()) dom.resumeBanner.classList.remove('hidden');
+        })();
 
         const SITE_PROFILES_KEY = 'siteProfiles';
         const loadProfiles = () => { try { return JSON.parse(localStorage.getItem(SITE_PROFILES_KEY) || '{}'); } catch { return {}; } };
@@ -479,64 +493,81 @@
             
             const linksArray = Array.from(allLinksToVisit);
             if (linksArray.length === 0) throw new Error(`No valid links found after crawl.`);
-
-            await processUrlsInParallel(linksArray, 'Scraping sub-page');
+            await ScraperDB.clearAll();
+            await ScraperDB.enqueueUrls(linksArray);
+            await ScraperDB.saveSettings({ concurrency: dom.concurrencySlider.value, delay: dom.delayInput.value });
+            state.scrapeResults = [];
+            await processUrlsInParallel('Scraping sub-page');
         }
 
         async function runBulkScrape() {
             const urls = dom.urlList.value.trim().split('\n').filter(Boolean).map(url => cleanUrl(validate.url(url)));
             if (urls.length === 0) throw new Error('Please paste at least one valid URL.');
-            await processUrlsInParallel(urls, 'Scraping URL');
+            await ScraperDB.clearAll();
+            await ScraperDB.enqueueUrls(urls);
+            await ScraperDB.saveSettings({ concurrency: dom.concurrencySlider.value, delay: dom.delayInput.value });
+            state.scrapeResults = [];
+            await processUrlsInParallel('Scraping URL');
         }
 
-        async function processUrlsInParallel(urls, statusPrefix) {
-            let completed = 0;
+        function renderResults() {
+            dom.resultsCode.textContent = state.scrapeResults
+                .filter(Boolean).sort((a, b) => a.index - b.index)
+                .map(r => {
+                    let output = `\n\n--- Content from ${r.url} ---\n\n`;
+                    if(r.error) output += `Error: ${r.error}`;
+                    else {
+                        if(r.metadata.title) output += `Title: ${r.metadata.title}\n`;
+                        if(r.metadata.author) output += `Author: ${r.metadata.author}\n`;
+                        if(r.metadata.published_at) output += `Published: ${r.metadata.published_at}\n`;
+                        if(r.metadata.description) output += `Description: ${r.metadata.description}\n\n`;
+                        output += r.text;
+                    }
+                    return output;
+                }).join('');
+        }
+
+        async function processUrlsInParallel(statusPrefix) {
+            let completed = state.scrapeResults.filter(Boolean).length;
             const maxConcurrency = parseInt(dom.concurrencySlider.value, 10);
             const perRequestDelay = parseInt(dom.delayInput.value, 10);
-            const urlQueue = [...new Set(urls)].map((url, index) => ({ index, url }));
-            const totalUrls = urlQueue.length;
-            state.scrapeResults = new Array(totalUrls);
-
-            const renderResults = () => {
-                dom.resultsCode.textContent = state.scrapeResults
-                    .filter(Boolean).sort((a, b) => a.index - b.index)
-                    .map(r => {
-                        let output = `\n\n--- Content from ${r.url} ---\n\n`;
-                        if(r.error) output += `Error: ${r.error}`;
-                        else {
-                            if(r.metadata.title) output += `Title: ${r.metadata.title}\n`;
-                            if(r.metadata.author) output += `Author: ${r.metadata.author}\n`;
-                            if(r.metadata.published_at) output += `Published: ${r.metadata.published_at}\n`;
-                            if(r.metadata.description) output += `Description: ${r.metadata.description}\n\n`;
-                            output += r.text;
-                        }
-                        return output;
-                    }).join('');
-            };
+            const totalUrls = await ScraperDB.countQueue();
 
             async function worker() {
-                while (urlQueue.length > 0 && !state.runControls.aborted) {
+                while (!state.runControls.aborted) {
                     await cooperativelyYield();
                     if (state.runControls.aborted) break;
-                    
-                    const { index, url } = urlQueue.shift();
+
+                    const item = await ScraperDB.getNext();
+                    if (!item) break;
+                    const { id, url, index } = item;
                     try {
                         dom.statusText.textContent = `${statusPrefix} (${completed + 1}/${totalUrls}): ${url.substring(0, 50)}...`;
                         const html = await api.fetchUrl(url);
                         const doc = new DOMParser().parseFromString(html, 'text/html');
                         const metadata = extractMetadata(doc);
                         const text = extractMainContent(doc);
-                        state.scrapeResults[index] = { index, url, text, metadata, html: dom.includeHtmlToggle.checked ? html : null, success: true };
+                        const result = { index, url, text, metadata, html: dom.includeHtmlToggle.checked ? html : null, success: true };
+                        state.scrapeResults[index] = result;
+                        await ScraperDB.markComplete(id, result);
                     } catch (error) {
-                        state.scrapeResults[index] = { index, url, text: '', metadata: {}, success: false, error: error.message, html: null };
+                        const result = { index, url, text: '', metadata: {}, success: false, error: error.message, html: null };
+                        state.scrapeResults[index] = result;
+                        await ScraperDB.markFailed(id, result);
                     } finally {
                         completed++;
                         renderResults();
+                        if (completed % 10 === 0) {
+                            await ScraperDB.saveSettings({
+                                concurrency: maxConcurrency,
+                                delay: perRequestDelay
+                            });
+                        }
                     }
                     await delay(perRequestDelay);
                 }
             }
-            
+
             const workers = Array(Math.min(maxConcurrency, totalUrls)).fill(null).map(worker);
             dom.resultsContainer.style.display = 'block';
             await Promise.all(workers);
@@ -621,6 +652,22 @@
                 dom.copyBtn.textContent = 'Copied!';
                 setTimeout(() => { dom.copyBtn.textContent = 'Copy'; }, 2000);
             } catch (err) { showError('Failed to copy text.'); }
+        });
+
+        dom.continueBtn.addEventListener('click', async () => {
+            dom.resumeBanner.classList.add('hidden');
+            const { results, settings } = await ScraperDB.loadState();
+            state.scrapeResults = [];
+            results.forEach(r => { state.scrapeResults[r.index] = r; });
+            if (settings.concurrency) dom.concurrencySlider.value = settings.concurrency;
+            if (settings.delay) dom.delayInput.value = settings.delay;
+            renderResults();
+            await processUrlsInParallel('Resuming URL');
+        });
+
+        dom.restartBtn.addEventListener('click', async () => {
+            await ScraperDB.clearAll();
+            dom.resumeBanner.classList.add('hidden');
         });
     </script>
 </body>

--- a/tests/sessionResume.test.js
+++ b/tests/sessionResume.test.js
@@ -1,0 +1,37 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const FDBFactory = require('fake-indexeddb/lib/FDBFactory');
+
+global.indexedDB = new FDBFactory();
+
+let ScraperDB = require('../public/idb.js');
+
+async function setupInitialRun(){
+  await ScraperDB.init();
+  await ScraperDB.saveSettings({ concurrency: 2, delay: 0 });
+  await ScraperDB.enqueueUrls(['http://a.com','http://b.com']);
+}
+
+test('session resumes after crash', async () => {
+  await setupInitialRun();
+  let item = await ScraperDB.getNext();
+  await ScraperDB.markComplete(item.id, { index:item.index, url:item.url, text:'A', metadata:{}, success:true });
+
+  // Simulate crash by reloading module
+  ScraperDB.close();
+  delete require.cache[require.resolve('../public/idb.js')];
+  ScraperDB = require('../public/idb.js');
+  await ScraperDB.init();
+  const state = await ScraperDB.loadState();
+  assert.equal(state.results.length, 1);
+  assert.equal(state.queue.filter(q=>q.status==='complete').length, 1);
+  assert.equal(state.settings.concurrency, 2);
+
+  // resume processing
+  item = await ScraperDB.getNext();
+  await ScraperDB.markComplete(item.id, { index:item.index, url:item.url, text:'B', metadata:{}, success:true });
+
+  const final = await ScraperDB.loadState();
+  assert.equal(final.results.length, 2);
+  assert.ok(!(await ScraperDB.hasUnfinished()));
+});


### PR DESCRIPTION
## Summary
- add IndexedDB helper with queue, results, settings, and log stores
- use IndexedDB for URL queue and result persistence; resume banner allows continuing or restarting runs
- add integration test to verify session resumes after a crash

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf22804320832bb69cd26c37deaedc