### PR TITLE
Improve JSON parsing in get-schema

### DIFF
--- a/tests/extractTextSafeParseJson.test.js
+++ b/tests/extractTextSafeParseJson.test.js
@@ -48,3 +48,15 @@ test('returns null for invalid JSON', () => {
   // Malformed input that cannot be parsed
   assert.strictEqual(safeParseJson('not json'), null);
 });
+
+test('handles multiple JSON blocks and returns first', () => {
+  const text = 'start {"a":1} middle {"b":2} end';
+  // Should parse only the first JSON object
+  assert.deepStrictEqual(safeParseJson(text), { a: 1 });
+});
+
+test('handles braces inside strings', () => {
+  const text = 'prefix {"a":"{braces}"} suffix';
+  // Braces within string values should not break parsing
+  assert.deepStrictEqual(safeParseJson(text), { a: '{braces}' });
+});


### PR DESCRIPTION
## Summary
- parse balanced JSON blocks in `safeParseJson`
- add tests for multiple JSON objects and braces within strings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf269d91b8832ba254e560febe79ff