### PR TITLE
fix netlify function bundling

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,9 @@
   publish = "public"
   functions = "netlify/functions"
 
+[functions]
+  node_bundler = "esbuild"
+
 # Proxy API routes to Netlify Functions
 [[redirects]]
   from = "/api/fetch-url"


### PR DESCRIPTION
## Summary
- bundle Netlify functions with esbuild so imports outside `netlify/functions` resolve correctly

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf34dc1ea0832bb3ecd7266ad6d684