### PR TITLE
feat: add headless rendering fallback

### DIFF
--- a/src/lib/browser/spa-renderer.js
+++ b/src/lib/browser/spa-renderer.js
@@ -1,0 +1,25 @@
+/**
+ * Headless browser renderer using Playwright
+ * Provides HTML rendering for JavaScript-driven (SPA) routes.
+ */
+
+const { chromium } = require('playwright');
+
+/**
+ * Render a SPA route and return the raw HTML.
+ * @param {string} url - URL to render
+ * @returns {Promise<string>} Rendered HTML string
+ */
+async function renderSpaPage(url) {
+  const browser = await chromium.launch({ headless: true });
+  try {
+    const page = await browser.newPage();
+    await page.goto(url, { waitUntil: 'networkidle' });
+    const content = await page.content();
+    return content;
+  } finally {
+    await browser.close();
+  }
+}
+
+module.exports = { renderSpaPage };


### PR DESCRIPTION
## Summary
- add Playwright-based SPA renderer for headless page rendering
- retry D2P manufacturer 404s with headless browser and expose rendered DOM

## Testing
- `npm test` *(fails: The error is expected to be an instance of "CircuitOpenError". Received "NetworkError". fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c34bed58c0832b9580d66609a078bf