### PR TITLE
Fix Netlify backend authentication error

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -57,6 +57,11 @@
   status = 200
 
 [[redirects]]
+  from = "/api/health"
+  to = "/.netlify/functions/health"
+  status = 200
+
+[[redirects]]
   from = "/api/jobs/export"
   to = "/.netlify/functions/jobs-export"
   status = 200

--- a/netlify/functions/health.js
+++ b/netlify/functions/health.js
@@ -1,0 +1,32 @@
+/**
+ * Netlify Function: health
+ * Public health check that verifies the Functions runtime is working.
+ */
+
+exports.handler = async (event) => {
+  const headers = {
+    'Access-Control-Allow-Origin': process.env.ALLOWED_ORIGINS || 'http://localhost:3000',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Allow-Methods': 'GET, OPTIONS',
+    'Content-Type': 'application/json',
+  };
+
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers, body: '' };
+  }
+
+  if (event.httpMethod !== 'GET') {
+    return {
+      statusCode: 405,
+      headers,
+      body: JSON.stringify({ error: { code: 'method_not_allowed', message: 'Only GET method is allowed' } }),
+    };
+  }
+
+  return {
+    statusCode: 200,
+    headers,
+    body: JSON.stringify({ ok: true, data: { status: 'healthy' } }),
+  };
+};
+

--- a/public/index.html
+++ b/public/index.html
@@ -714,10 +714,9 @@
 
         async function verifyBackend() {
             try {
-                const res = await fetch('/api/fetch-url?url=https://example.com');
+                const res = await fetch('/api/health');
                 const text = await res.text();
-                const correlationId = res.headers.get('x-correlation-id');
-                log(correlationId ? `[${correlationId}]` : '', `[verifyBackend] [${res.status}]`, text.substring(0, 200));
+                log(`[verifyBackend] [${res.status}]`, text.substring(0, 200));
                 if (!res.ok) throw new Error(`Backend returned ${res.status}`);
                 return true;
             } catch (e) {


### PR DESCRIPTION
Add a public health check endpoint and update frontend verification to use it, resolving a 401 error from calling a protected endpoint.

The `verifyBackend` function in `public/index.html` was incorrectly calling the protected `/api/fetch-url` endpoint without an authentication token, leading to a "Backend returned 401" error. This PR introduces a dedicated, unauthenticated `/api/health` endpoint to serve as a basic backend availability check, preventing the 401 error and ensuring proper frontend initialization.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f02a52b-faca-47ab-9555-4242bf257cd5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9f02a52b-faca-47ab-9555-4242bf257cd5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

