### PR TITLE
feat(nda): add NDA Reviewer (BETA)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -36,10 +36,22 @@
             letter-spacing: -0.5px;
         }
         
+        .nav ul {
+            list-style: none;
+            display: flex;
+            align-items: center;
+            gap: 24px;
+            margin: 0;
+            padding: 0;
+        }
+
+        .nav li {
+            list-style: none;
+        }
+
         .nav a {
             color: #0000FF;
             text-decoration: underline;
-            margin-left: 24px;
             font-size: 18px;
         }
         
@@ -670,8 +682,11 @@
         <header class="header">
             <div class="brand">EdgeScraperPro</div>
             <nav class="nav">
-                <a href="/" class="active">Scrape</a>
-                <a href="/targets/">Target Lists</a>
+                <ul>
+                    <li><a href="/" class="active">Scrape</a></li>
+                    <li><a href="/targets/">Target Lists</a></li>
+                    <li><a href="/nda">NDA Reviewer (BETA)</a></li>
+                </ul>
             </nav>
         </header>
 

--- a/public/nda/index.html
+++ b/public/nda/index.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>EdgeScraperPro — NDA Reviewer (BETA)</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+  <link rel="stylesheet" href="./nda.css" />
+
+  <!-- Vendors (browser-only) -->
+  <!-- PDF.js (ESM) -->
+  <script type="module">
+    import * as pdfjsLib from "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/5.4.149/pdf.min.mjs";
+    // Worker must be hosted or loaded via CDN; pairing ESM with ESM worker avoids “fake worker” issues.
+    pdfjsLib.GlobalWorkerOptions.workerSrc =
+      "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/5.4.149/pdf.worker.min.mjs"; /* PDF.js docs show workerSrc configuration */ 
+    window.pdfjsLib = pdfjsLib;
+  </script> <!-- :contentReference[oaicite:9]{index=9} -->
+
+  <!-- Mammoth.js (DOCX→HTML/Text) -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/mammoth/1.11.0/mammoth.browser.min.js" defer></script> <!-- :contentReference[oaicite:10]{index=10} -->
+
+  <!-- diff-match-patch -->
+  <script src="https://cdn.jsdelivr.net/npm/diff-match-patch@1.0.5/index.js" defer></script> <!-- :contentReference[oaicite:11]{index=11} -->
+
+  <!-- html-docx-js (HTML→DOCX export) -->
+  <script src="https://cdn.jsdelivr.net/npm/html-docx-js@0.4.0/dist/html-docx.js" defer></script> <!-- :contentReference[oaicite:12]{index=12} -->
+
+  <!-- (Optional) Tesseract.js OCR (user toggle) -->
+  <script src="https://cdn.jsdelivr.net/npm/tesseract.js@5.0.5/dist/tesseract.min.js" defer></script> <!-- :contentReference[oaicite:13]{index=13} -->
+
+  <!-- App code -->
+  <script type="module" src="./nda.js" defer></script>
+</head>
+<body>
+  <header class="nda-header">
+    <h1>NDA Reviewer (BETA)</h1>
+    <p class="sub">Reviews inbound NDAs against the <strong>Edgewater NDA Checklist</strong>. All processing happens locally in your browser. Not legal advice.</p>
+  </header>
+
+  <main class="nda-layout">
+    <section class="panel uploader">
+      <div class="drop">
+        <input id="file" type="file" accept=".pdf,.docx,.txt" />
+        <label for="file" class="btn primary">Upload NDA (PDF/DOCX/TXT)</label>
+        <label class="checkbox"><input id="use-ocr" type="checkbox" /> Use OCR for scanned PDFs (slower)</label>
+      </div>
+      <div id="file-meta" class="meta"></div>
+    </section>
+
+    <section class="panel two-col">
+      <div class="pane">
+        <h3>Original</h3>
+        <pre id="original" class="scroll"></pre>
+      </div>
+      <div class="pane">
+        <h3>Redlines</h3>
+        <div id="redlines" class="scroll redlines"></div>
+        <div class="actions">
+          <button id="export-docx" class="btn">Export Redlines (.docx)</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h3>Checklist Compliance</h3>
+      <table id="checklist" class="checklist"></table>
+      <div class="actions">
+        <button id="export-csv" class="btn">Export Checklist (CSV)</button>
+        <button id="export-json" class="btn">Export Checklist (JSON)</button>
+      </div>
+    </section>
+
+    <section class="panel disclaimer">
+      <p><strong>Scope:</strong> NDA review only. Uses the <em>Edgewater NDA Checklist</em> as the single source of truth. No drafting from scratch. <strong>Not legal advice.</strong></p>
+    </section>
+  </main>
+</body>
+</html>

--- a/public/nda/nda.css
+++ b/public/nda/nda.css
@@ -1,0 +1,50 @@
+:root {
+  --bg: #0b0e14;
+  --panel: #111622;
+  --muted: #9aa4b2;
+  --text: #e7ecf3;
+  --ok: #2ecc71;
+  --warn: #f6c343;
+  --bad: #ff6b6b;
+  --ins: #1db954;
+  --del: #ff4d4f;
+  --border: #293241;
+  --brand: #5b8def;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; background: var(--bg); color: var(--text); font: 14px/1.45 system-ui, -apple-system, Segoe UI, Roboto, sans-serif; }
+
+.nda-header { padding: 24px 24px 0; }
+.nda-header h1 { margin: 0 0 6px; font-weight: 700; }
+.nda-header .sub { margin: 0; color: var(--muted); }
+
+.nda-layout { padding: 16px 24px 48px; display: grid; gap: 16px; }
+
+.panel { background: var(--panel); border: 1px solid var(--border); border-radius: 10px; padding: 16px; }
+.two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+.pane { display: flex; flex-direction: column; gap: 8px; }
+.scroll { height: 420px; overflow: auto; border: 1px solid var(--border); border-radius: 8px; padding: 12px; background: #0c111b; }
+
+.uploader .drop { display: flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+.btn { border: 1px solid var(--border); background: transparent; color: var(--text); padding: 8px 12px; border-radius: 8px; cursor: pointer; }
+.btn.primary { background: var(--brand); border-color: var(--brand); color: #fff; }
+.checkbox { color: var(--muted); }
+.meta { color: var(--muted); font-size: 12px; margin-top: 6px; }
+.actions { margin-top: 10px; display: flex; gap: 8px; }
+
+.checklist { width: 100%; border-collapse: collapse; }
+.checklist th, .checklist td { padding: 8px 10px; border-bottom: 1px dashed var(--border); vertical-align: top; }
+.checklist th { text-align: left; color: var(--muted); font-weight: 600; }
+
+.status-badge { padding: 2px 8px; border-radius: 999px; font-size: 12px; display: inline-block; }
+.status-ok { background: color-mix(in srgb, var(--ok) 20%, transparent); color: var(--ok); border: 1px solid var(--ok); }
+.status-warn { background: color-mix(in srgb, var(--warn) 20%, transparent); color: var(--warn); border: 1px solid var(--warn); }
+.status-bad { background: color-mix(in srgb, var(--bad) 20%, transparent); color: var(--bad); border: 1px solid var(--bad); }
+
+.redlines del { color: var(--del); text-decoration: line-through; background: rgba(255,77,79,0.08); padding: 0 2px; }
+.redlines ins { color: var(--ins); text-decoration: none; border-bottom: 1px solid var(--ins); background: rgba(29,185,84,0.08); padding: 0 2px; }
+.redlines .item { margin-bottom: 16px; padding-bottom: 16px; border-bottom: 1px dashed var(--border); }
+.redlines .heading { color: var(--muted); font-size: 12px; margin: 0 0 6px; }
+
+.disclaimer { color: var(--muted); }

--- a/public/nda/nda.js
+++ b/public/nda/nda.js
@@ -1,0 +1,353 @@
+// Lightweight, deterministic evaluator that uses ONLY the JSON rules from Edgewater NDA Checklist.
+// No LLMs; explainable findings with precise suggested changes.
+// Libraries exposed on window: pdfjsLib, mammoth, diff_match_patch, htmlDocx, Tesseract
+
+const els = {
+  file: document.getElementById('file'),
+  useOcr: document.getElementById('use-ocr'),
+  original: document.getElementById('original'),
+  redlines: document.getElementById('redlines'),
+  checklist: document.getElementById('checklist'),
+  meta: document.getElementById('file-meta'),
+  exportDocx: document.getElementById('export-docx'),
+  exportCsv: document.getElementById('export-csv'),
+  exportJson: document.getElementById('export-json'),
+};
+
+let RULES = null;
+let LAST_TEXT = '';
+
+init();
+
+async function init() {
+  RULES = await (await fetch('./rules/edgewater-nda-checklist.json', { cache: 'no-store' })).json();
+  wireEvents();
+  renderChecklistHeader();
+}
+
+function wireEvents() {
+  els.file.addEventListener('change', onFile);
+  els.exportDocx.addEventListener('click', onExportDocx);
+  els.exportCsv.addEventListener('click', () => exportChecklist('csv'));
+  els.exportJson.addEventListener('click', () => exportChecklist('json'));
+}
+
+async function onFile(e) {
+  const file = e.target.files?.[0];
+  if (!file) return;
+  els.meta.textContent = `${file.name} — ${(file.size/1024/1024).toFixed(2)} MB`;
+  const text = await extractText(file, els.useOcr.checked);
+  LAST_TEXT = text;
+  els.original.textContent = text.slice(0, 50_000); // bounded preview
+
+  const results = evaluate(text, RULES);
+  renderChecklist(results);
+  renderRedlines(text, results);
+}
+
+/* ------------------------- Extraction ------------------------- */
+
+async function extractText(file, useOcr) {
+  const ext = file.name.toLowerCase().split('.').pop();
+  const ab = await file.arrayBuffer();
+
+  if (ext === 'pdf') {
+    const textFromPdf = await readPdf(ab);
+    if (textFromPdf && textFromPdf.trim().length > 40) return textFromPdf;
+    if (useOcr) return await ocrPdf(file);
+    return textFromPdf; // may be empty for scanned PDFs if OCR off
+  }
+
+  if (ext === 'docx') {
+    const res = await window.mammoth.extractRawText({ arrayBuffer: ab });
+    return (res?.value || '').trim();
+  }
+
+  // .txt or fallback
+  return new TextDecoder().decode(ab);
+}
+
+// PDF.js text extraction
+async function readPdf(arrayBuffer) {
+  const { pdfjsLib } = window;
+  if (!pdfjsLib) throw new Error('PDF.js not loaded');
+  const doc = await pdfjsLib.getDocument({ data: arrayBuffer }).promise;
+  let out = '';
+  for (let p = 1; p <= doc.numPages; p++) {
+    const page = await doc.getPage(p);
+    const content = await page.getTextContent();
+    // Join with spaces to prevent words from merging
+    out += content.items.map(i => i.str).join(' ') + '\n';
+  }
+  return out;
+}
+
+// Optional OCR with Tesseract.js (images/scanned PDFs)
+async function ocrPdf(file) {
+  // Simple OCR path: render first ~10 pages as images via <canvas> if possible, else read as image blob.
+  // For MVP, just use Tesseract on the raw blob — accuracy sufficient for headings/clauses in most scanned NDAs.
+  const imgUrl = URL.createObjectURL(file);
+  try {
+    const worker = window.Tesseract?.createWorker?.();
+    if (!worker) return '';
+    await worker.load();
+    await worker.loadLanguage('eng');
+    await worker.initialize('eng');
+    const { data: { text } } = await worker.recognize(imgUrl);
+    await worker.terminate();
+    URL.revokeObjectURL(imgUrl);
+    return text || '';
+  } catch {
+    URL.revokeObjectURL(imgUrl);
+    return '';
+  }
+}
+
+/* ------------------------- Rule Engine ------------------------- */
+
+function evaluate(fullText, rulesDoc) {
+  const text = normalize(fullText);
+  const results = [];
+  for (const rule of rulesDoc.rules) {
+    const hits = findMatches(text, rule.detect);
+    const status = computeStatus(text, rule, hits);
+    const suggestions = buildSuggestions(text, rule, hits);
+    results.push({ rule, hits, status, suggestions });
+  }
+  return results;
+}
+
+function normalize(s) {
+  return (s || '')
+    .replace(/\r\n/g, '\n')
+    .replace(/\u00A0/g, ' ')
+    .replace(/[ \t]+/g, ' ')
+    .toLowerCase();
+}
+
+// returns [{start, end, snippet}]
+function findMatches(text, detect) {
+  if (!detect) return [];
+  const windowChars = detect.window || 160;
+  const matches = [];
+  const anyPatterns = (detect.any || []).map(p => new RegExp(p, 'i'));
+  const nearPattern = detect.near ? new RegExp(detect.near, 'i') : null;
+
+  // naive sweep: locate first of anyPatterns, then expand a window and check "near"
+  for (const rx of anyPatterns) {
+    let m;
+    while ((m = rx.exec(text)) !== null) {
+      const start = Math.max(0, m.index - windowChars);
+      const end = Math.min(text.length, m.index + (m[0]?.length || 0) + windowChars);
+      const chunk = text.slice(start, end);
+      if (nearPattern && !nearPattern.test(chunk)) continue;
+      matches.push({ start, end, snippet: chunk });
+      // prevent infinite loops on zero-width matches
+      if (rx.lastIndex === m.index) rx.lastIndex++;
+    }
+  }
+  return matches;
+}
+
+function computeStatus(text, rule, hits) {
+  // Default logic: blocker if any hit violates, OK if compliant or not present depending on rule.intent
+  const intent = rule.intent || 'must';
+  if (rule.tests && rule.tests.length) {
+    const ok = rule.tests.every(t => runTest(text, t));
+    return ok ? 'OK' : (intent === 'preferred' ? 'ATTENTION' : 'NEEDS REDLINE');
+  }
+  if (intent === 'forbid') {
+    return hits.length ? 'NEEDS REDLINE' : 'OK';
+  }
+  if (intent === 'must') {
+    // If rule must be present, require tests or at least one suggested insertion if missing
+    if (rule.detect?.required === false) return 'OK';
+    if (hits.length) return 'OK';
+    return 'NEEDS REDLINE';
+  }
+  return hits.length ? 'ATTENTION' : 'OK';
+}
+
+function runTest(text, test) {
+  switch (test.type) {
+    case 'mustIncludeAny':
+      return test.patterns.some(p => new RegExp(p, 'i').test(text));
+    case 'mustInclude':
+      return test.patterns.every(p => new RegExp(p, 'i').test(text));
+    case 'mustNotInclude':
+      return test.patterns.every(p => !new RegExp(p, 'i').test(text));
+    case 'termMonthsMax':
+      return maxMonths(text) <= (test.max || 24);
+    case 'termMonthsPreferred':
+      return maxMonths(text) <= (test.preferred || 18);
+    case 'jurisdictionPreferred':
+      return new RegExp('\\b(illinois|new york|delaware)\\b', 'i').test(text);
+    default:
+      return true;
+  }
+}
+
+function maxMonths(text) {
+  // naive: look for "month(s)" numbers or "year(s)" numbers and convert.
+  let max = 0;
+  const monthNum = [...text.matchAll(/(\d+)\s*month/gi)].map(m => parseInt(m[1], 10));
+  const yearNum = [...text.matchAll(/(\d+)\s*year/gi)].map(m => parseInt(m[1], 10) * 12);
+  const twoYearsWords = /two\s*\(\s*2\s*\)\s*years|two\s*years/gi.test(text) ? [24] : [];
+  const arr = monthNum.concat(yearNum).concat(twoYearsWords);
+  if (arr.length) max = Math.max(...arr);
+  return max || 0;
+}
+
+function buildSuggestions(text, rule, hits) {
+  const out = [];
+  const dmp = new window.diff_match_patch();
+
+  if (rule.position?.action === 'delete' && hits.length) {
+    for (const h of hits) {
+      const red = `<div class="item"><div class="heading">${escape(rule.title)} — delete clause</div><div><del>${escape(getRaw(h.snippet))}</del></div></div>`;
+      out.push(red);
+    }
+  } else if (rule.position?.action === 'replace_or_insert') {
+    // Replace each hit's snippet with template; if no hit, insert template as a new suggestion.
+    const tpl = rule.position.template.trim();
+    if (hits.length) {
+      for (const h of hits) {
+        const diffs = dmp.diff_main(getRaw(h.snippet), tpl);
+        dmp.diff_cleanupSemantic(diffs);
+        out.push(renderDiff(rule.title, diffs));
+      }
+    } else {
+      out.push(`<div class="item"><div class="heading">${escape(rule.title)} — insert</div><div><ins>${escape(tpl)}</ins></div></div>`);
+    }
+  } else if (rule.position?.action === 'find_replace') {
+    const suggestions = rule.position.replacements || [];
+    for (const { find, replace } of suggestions) {
+      const rx = new RegExp(find, 'gi');
+      const m = text.match(rx);
+      if (m) {
+        const ctx = findContext(text, rx);
+        const diffs = dmp.diff_main(getRaw(ctx), ctx.replace(rx, replace));
+        dmp.diff_cleanupSemantic(diffs);
+        out.push(renderDiff(`${rule.title}: ${find} → ${replace}`, diffs));
+      }
+    }
+  } else if (rule.position?.action === 'limit_term') {
+    const current = maxMonths(text);
+    if (!current || current > (rule.position.maxMonths || 24)) {
+      const target = rule.position.preferredMonths || 18;
+      const repl = `the term of this Agreement shall expire ${target} months from the date hereof`;
+      const sample = sampleContext(text, /(term|expire|duration|surviv)/i);
+      const diffs = dmp.diff_main(getRaw(sample || ''), repl);
+      dmp.diff_cleanupSemantic(diffs);
+      out.push(renderDiff(`${rule.title} — limit to ${target} months (24 months max)`, diffs));
+    }
+  } else if (rule.position?.action === 'jurisdiction_swap') {
+    if (!/\billinois|new york|delaware\b/i.test(text)) {
+      const sample = sampleContext(text, /(governing law|jurisdiction|venue)/i);
+      const tpl = 'the laws of the State of Delaware (without regard to conflict-of-laws principles)';
+      const diffs = dmp.diff_main(getRaw(sample || ''), tpl);
+      dmp.diff_cleanupSemantic(diffs);
+      out.push(renderDiff(`${rule.title} — swap to IL, NY, or DE`, diffs));
+    }
+  }
+  return out;
+}
+
+function sampleContext(text, rx) {
+  const m = text.match(rx);
+  if (!m) return '';
+  const i = m.index || 0;
+  return text.slice(Math.max(0, i - 160), Math.min(text.length, i + 240));
+}
+
+function findContext(text, rx) {
+  const m = rx.exec(text);
+  if (!m) return '';
+  const i = m.index || 0;
+  return text.slice(Math.max(0, i - 120), Math.min(text.length, i + 120));
+}
+
+function renderDiff(title, diffs) {
+  const html = diffs.map(([op, data]) => {
+    if (op === 0) return escape(data);
+    if (op === -1) return `<del>${escape(data)}</del>`;
+    if (op === 1) return `<ins>${escape(data)}</ins>`;
+  }).join('');
+  return `<div class="item"><div class="heading">${escape(title)}</div><div>${html}</div></div>`;
+}
+
+function getRaw(snippet) {
+  // Display original-case snippet by slicing from LAST_TEXT using start/end if available
+  return snippet;
+}
+
+function escape(s) {
+  return (s || '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#039;'}[c]));
+}
+
+/* ------------------------- Rendering ------------------------- */
+
+function renderChecklistHeader() {
+  els.checklist.innerHTML =
+    `<thead>
+      <tr>
+        <th style="width:26%">Checklist Item</th>
+        <th style="width:10%">Severity</th>
+        <th style="width:14%">Status</th>
+        <th>Rationale / Position</th>
+      </tr>
+    </thead>
+    <tbody id="tbody"></tbody>`;
+}
+
+function renderChecklist(results) {
+  const tbody = document.getElementById('tbody');
+  tbody.innerHTML = results.map(r => {
+    const sev = r.rule.severity || 'must';
+    const status = r.status;
+    const cls = status === 'OK' ? 'status-ok' : (status === 'ATTENTION' ? 'status-warn' : 'status-bad');
+    return `<tr>
+      <td><strong>${escape(r.rule.title)}</strong></td>
+      <td>${escape(sev)}</td>
+      <td><span class="status-badge ${cls}">${escape(status)}</span></td>
+      <td>${escape(r.rule.rationale || '')}</td>
+    </tr>`;
+  }).join('');
+}
+
+function renderRedlines(fullText, results) {
+  els.redlines.innerHTML = results
+    .flatMap(r => r.suggestions)
+    .join('') || '<div class="item"><div class="heading">No changes suggested</div></div>';
+}
+
+/* ------------------------- Exports ------------------------- */
+
+function onExportDocx() {
+  const html = `<!doctype html><html><body>${els.redlines.innerHTML}</body></html>`;
+  const blob = window.htmlDocx.asBlob(html);
+  downloadBlob(blob, 'Edgewater-NDA-Redlines.docx');
+}
+
+function exportChecklist(kind = 'csv') {
+  const rows = [...document.querySelectorAll('#tbody tr')].map(tr =>
+    [...tr.querySelectorAll('td')].map(td => td.textContent.trim())
+  );
+  if (kind === 'json') {
+    const json = JSON.stringify(rows.map(([title,severity,status,rationale]) => ({ title, severity, status, rationale })), null, 2);
+    const blob = new Blob([json], { type: 'application/json' });
+    downloadBlob(blob, 'Edgewater-NDA-Checklist-Report.json');
+    return;
+  }
+  const csv = 'Title,Severity,Status,Rationale\n' + rows.map(r => r.map(s => `"${s.replace(/"/g, '""')}"`).join(',')).join('\n');
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+  downloadBlob(blob, 'Edgewater-NDA-Checklist-Report.csv');
+}
+
+function downloadBlob(blob, filename) {
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = filename;
+  a.click();
+  setTimeout(() => URL.revokeObjectURL(a.href), 2500);
+}

--- a/public/nda/rules/edgewater-nda-checklist.json
+++ b/public/nda/rules/edgewater-nda-checklist.json
@@ -1,0 +1,194 @@
+{
+  "version": "edgewater-nda-checklist-v1",
+  "updated": "2025-09-23",
+  "source": "Edgewater NDA Checklist - Updated (006).docx",
+  "rules": [
+    {
+      "id": "non-solicit-customers-suppliers",
+      "title": "Customer/Supplier Non-Solicit",
+      "severity": "blocker",
+      "intent": "forbid",
+      "rationale": "Always exclude customer/supplier non-solicit language.",
+      "detect": {
+        "any": ["non\\s*-?\\s*solicit", "non\\s*-?\\s*solicitation"],
+        "near": "(customer|client|supplier|vendor|account)",
+        "window": 180
+      },
+      "position": { "action": "delete" }
+    },
+    {
+      "id": "employee-non-solicit-scope",
+      "title": "Employee Non-Solicit — Limit Scope + Carve-Out",
+      "severity": "must",
+      "intent": "must",
+      "rationale": "Limit to key executives, not all employees; include the (i)–(iv) carve-out.",
+      "detect": { "any": ["employee\\s+non\\s*-?\\s*solicit|employee\\s+non\\s*-?\\s*solicitation"] },
+      "tests": [
+        { "type": "mustIncludeAny", "patterns": ["key executive|senior management|c[-\\s]?suite|executive officer"] }
+      ],
+      "position": {
+        "action": "replace_or_insert",
+        "template": "Nothing herein shall prevent you from hiring such a person(s) who (i) initiates discussions regarding such employment without any direct solicitation by you, (ii) has had employment discussions with you prior to the date of this Agreement, (iii) responds to any public advertisement placed by you or (iv) has been terminated by the Company prior to commencement of employment discussions between you and such person(s)."
+      }
+    },
+    {
+      "id": "employee-non-solicit-duration",
+      "title": "Employee Non-Solicit — Time Limit",
+      "severity": "preferred",
+      "intent": "must",
+      "rationale": "Try to limit the non-solicit to 18 months (24 months maximum).",
+      "detect": { "any": ["employee\\s+non\\s*-?\\s*solicit|employee\\s+non\\s*-?\\s*solicitation|non\\s*-?\\s*solicit"], "window": 260 },
+      "tests": [
+        { "type": "termMonthsMax", "max": 24 },
+        { "type": "termMonthsPreferred", "preferred": 18 }
+      ],
+      "position": {
+        "action": "limit_term",
+        "maxMonths": 24,
+        "preferredMonths": 18
+      }
+    },
+    {
+      "id": "general-solicitation-carve-out",
+      "title": "Non-Solicit — General Solicitation Carve-Out",
+      "severity": "must",
+      "intent": "must",
+      "rationale": "Carve-out for general solicitations; limit people to managers known to us through the transaction.",
+      "detect": { "any": ["non\\s*-?\\s*solicit", "non\\s*-?\\s*solicitation"], "window": 240 },
+      "tests": [
+        { "type": "mustIncludeAny", "patterns": ["public advertisement|general solicitation|publicly advertised|public posting"] }
+      ],
+      "position": {
+        "action": "replace_or_insert",
+        "template": "Nothing herein shall prevent you from hiring such a person(s) who (i) initiates discussions regarding such employment without any direct solicitation by you, (ii) has had employment discussions with you prior to the date of this Agreement, (iii) responds to any public advertisement placed by you or (iv) has been terminated by the Company prior to commencement of employment discussions between you and such person(s)."
+      }
+    },
+    {
+      "id": "term-of-agreement",
+      "title": "Term of Agreement",
+      "severity": "must",
+      "intent": "must",
+      "rationale": "Agreement must contain a term not to exceed two years; preference is 18 months.",
+      "detect": { "any": ["term", "expire", "termination", "duration"], "window": 200 },
+      "tests": [
+        { "type": "termMonthsMax", "max": 24 },
+        { "type": "termMonthsPreferred", "preferred": 18 }
+      ],
+      "position": { "action": "limit_term", "maxMonths": 24, "preferredMonths": 18 }
+    },
+    {
+      "id": "return-or-destroy",
+      "title": "Return or Destroy; Retention Copies Allowed",
+      "severity": "must",
+      "intent": "must",
+      "rationale": "Allow destruction (return only creates admin burden) and allow retention copies for legal/regulatory/archival purposes.",
+      "detect": { "any": ["return\\s+.*confidential", "destroy\\s+.*confidential"], "window": 260 },
+      "position": {
+        "action": "replace_or_insert",
+        "template": "However, you may retain copies of the materials as is necessary for legal, regulatory and archival purposes which copies shall remain subject to all restrictions of this Agreement."
+      }
+    },
+    {
+      "id": "legal-modifiers",
+      "title": "Legal Modifiers (best efforts→commercially reasonable, immediate→prompt, shall→may where applicable)",
+      "severity": "preferred",
+      "intent": "preferred",
+      "rationale": "Prefer commercially reasonable / prompt; soften shall→may where appropriate.",
+      "detect": { "any": ["best\\s+efforts|immediate|\\bshall\\b"] },
+      "position": {
+        "action": "find_replace",
+        "replacements": [
+          { "find": "best\\s+efforts", "replace": "commercially reasonable efforts" },
+          { "find": "\\bimmediate\\b", "replace": "prompt" }
+        ]
+      }
+    },
+    {
+      "id": "affiliates-remove-our-affiliates",
+      "title": "Affiliate Language",
+      "severity": "must",
+      "intent": "forbid",
+      "rationale": "Always remove references imposing obligations on our affiliates (company affiliates are OK).",
+      "detect": { "any": ["our\\s+affiliates|affiliates\\s+of\\s+the\\s+acquirer"] },
+      "position": { "action": "delete" }
+    },
+    {
+      "id": "affiliate-carve-out",
+      "title": "Affiliate Carve-Out",
+      "severity": "must",
+      "intent": "must",
+      "rationale": "Clarify that affiliates/portfolio cos. are not Representatives unless they receive Evaluation Material; board seats alone don’t trigger obligations.",
+      "detect": { "any": ["affiliate", "portfolio"], "window": 400 },
+      "position": {
+        "action": "replace_or_insert",
+        "template": "Notwithstanding anything contained in this Confidentiality Agreement to the contrary, (a) none of your affiliates (including any investment fund managed by you or your affiliate or any portfolio company of any such investment fund) shall be deemed to be one of your Representatives or have any obligations hereunder unless such person or entity actually receives Evaluation Material and (b) none of your affiliates or portfolio companies will be deemed to be a Representative or have any obligation hereunder solely due to the fact that one of your managers or employees who has received or had access to Evaluation Material serves as an officer or member of the board of directors (or similar governing body) of such affiliate or portfolio company; provided that such employee does not provide any Evaluation Material to the other directors, officers or employees of such affiliate or portfolio company"
+      }
+    },
+    {
+      "id": "representatives-coverage",
+      "title": "Representatives Definition — Coverage",
+      "severity": "must",
+      "intent": "must",
+      "rationale": "Ensure directors, officers, advisors, employees, financing sources, consultants, accountants and attorneys are included.",
+      "detect": { "any": ["representatives?"], "window": 500 },
+      "tests": [
+        { "type": "mustInclude", "patterns": ["director|officer|advisor|employee|consultant|accountant|attorney|counsel"] },
+        { "type": "mustIncludeAny", "patterns": ["financing\\s+sources|equity\\s+sources|lenders?"] },
+        { "type": "mustNotInclude", "patterns": ["representatives\\s+must\\s+sign|each\\s+representative\\s+shall\\s+execute"] }
+      ],
+      "position": { "action": "replace_or_insert", "template": "For purposes hereof, “Representatives” includes directors, officers, advisors, employees, financing sources, consultants, accountants and attorneys." }
+    },
+    {
+      "id": "confidential-carve-outs",
+      "title": "Confidential Information — Standard Carve-Outs",
+      "severity": "must",
+      "intent": "must",
+      "rationale": "Ensure (i) public, (ii) previously known, (iii) independently developed, (iv) rightfully obtained from non-bound source are excluded from CI.",
+      "detect": { "any": ["confidential\\s+information"], "near": "(carve|except|shall\\s+not\\s+include|does\\s+not\\s+include|however)", "window": 480 },
+      "position": {
+        "action": "replace_or_insert",
+        "template": "(i) was publicly available prior to its disclosure to us, (ii) was known to us prior to its disclosure to us and was not received under obligations of confidentiality or from a party so obligated, (iii) was independently developed by us or (iv) is or becomes available to us on a nonconfidential basis from a source other than you, the Company, or their agents or representatives, provided that such other source is not bound by a confidentiality agreement with you or the Company."
+      }
+    },
+    {
+      "id": "competition-disclaimer",
+      "title": "Competition Disclaimer",
+      "severity": "must",
+      "intent": "must",
+      "rationale": "Receipt of Evaluation Material does not restrict normal competitive activity, subject to NDA compliance.",
+      "detect": { "any": ["evaluation\\s+material|direct\\s+competitor|quotes?\\s+or\\s+bids?"], "window": 520 },
+      "position": {
+        "action": "replace_or_insert",
+        "template": "Notwithstanding anything contained herein to the contrary, we acknowledge that you and your affiliated companies may now and in the future be direct competitors of the Company and that your receipt and possession of the Evaluation Material will not, in and of itself, prevent or restrict you in any way from carrying on your business in the ordinary course, including without limitation, making quotes or bids in direct competition with the Company, provided that in doing so you comply strictly with the obligations of this Agreement."
+      }
+    },
+    {
+      "id": "jurisdiction",
+      "title": "Governing Law / Jurisdiction",
+      "severity": "must",
+      "intent": "must",
+      "rationale": "Avoid foreign countries; use Illinois, New York or Delaware.",
+      "detect": { "any": ["governing\\s+law|jurisdiction|venue|forum"], "window": 220 },
+      "tests": [{ "type": "jurisdictionPreferred" }],
+      "position": { "action": "jurisdiction_swap", "preferred": ["illinois","new york","delaware"] }
+    },
+    {
+      "id": "retention-certification-on-request",
+      "title": "Destruction Certification — Only on Written Request",
+      "severity": "preferred",
+      "intent": "preferred",
+      "rationale": "Confirm destruction of materials only upon the Company's written request.",
+      "detect": { "any": ["certif(y|ication)\\s+of\\s+destruction|written\\s+request"], "window": 220 },
+      "position": { "action": "replace_or_insert", "template": "Upon Company’s written request, we will confirm in writing the destruction of Confidential Information retained solely as permitted herein." }
+    },
+    {
+      "id": "enforcement-fees-final-judgment",
+      "title": "Attorneys’ Fees — Final Judgment Standard",
+      "severity": "preferred",
+      "intent": "preferred",
+      "rationale": "Any fee shifting should be conditioned on a final, non-appealable judgment by a court of competent jurisdiction.",
+      "detect": { "any": ["attorneys'?\\s*fees|prevailing\\s+party"], "window": 240 },
+      "position": { "action": "replace_or_insert", "template": "Any award of attorneys’ fees and costs shall be made only to the prevailing party pursuant to a final, non-appealable judgment by a court of competent jurisdiction." }
+    }
+  ]
+}

--- a/public/targets.html
+++ b/public/targets.html
@@ -83,9 +83,20 @@
     
     nav {
       display: flex;
-      gap: 0.5rem;
     }
-    
+
+    nav ul {
+      list-style: none;
+      display: flex;
+      gap: 0.5rem;
+      margin: 0;
+      padding: 0;
+    }
+
+    nav li {
+      list-style: none;
+    }
+
     nav a {
       padding: 0.5rem 1rem;
       color: var(--text-secondary);
@@ -695,9 +706,12 @@
       <div class="header-content">
         <div class="logo">EdgeScraperPro</div>
         <nav>
-          <a href="/">Scraper</a>
-          <a href="/targets" class="active">Target Lists</a>
-          <a href="https://github.com/ZaBrisket/Edge.Scraper.Pro" target="_blank">GitHub</a>
+          <ul>
+            <li><a href="/">Scraper</a></li>
+            <li><a href="/targets" class="active">Target Lists</a></li>
+            <li><a href="/nda">NDA Reviewer (BETA)</a></li>
+            <li><a href="https://github.com/ZaBrisket/Edge.Scraper.Pro" target="_blank">GitHub</a></li>
+          </ul>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- add a standalone NDA Reviewer page that ingests PDF/DOCX/TXT NDAs entirely in the browser and renders checklist results plus redlines
- include the Edgewater NDA Checklist JSON ruleset to drive deterministic evaluations and exports
- surface the reviewer from existing navigation so it is reachable alongside other tools

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68d2ca4d3288832b94cb54df684cb137