### PR TITLE
Fix NDA Reviewer iframe blocked by frame options

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -54,7 +54,7 @@
   for = "/nda/*"
   [headers.values]
     X-Content-Type-Options = "nosniff"
-    X-Frame-Options = "DENY"
+    X-Frame-Options = "SAMEORIGIN"
     Referrer-Policy = "no-referrer"
 
 # Cache static assets


### PR DESCRIPTION
## Summary
- allow the NDA app bundle to be embedded in the site iframe by serving it with X-Frame-Options=SAMEORIGIN instead of DENY
- keep the stricter CSP and client-side frame guard to continue blocking unapproved parent origins

## Testing
- npm test *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d578479538832b9caccfe5e0d43bfd