### PR TITLE
Reorganize homepage tools and navigation

### DIFF
--- a/public/companies/index.html
+++ b/public/companies/index.html
@@ -12,11 +12,9 @@
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">Menu</button>
     <nav id="primary-nav" class="site-nav" aria-label="Primary">
       <a href="/" data-nav="home">Home</a>
-      <a href="/scrape/" data-nav="scrape">Scrape</a>
-      <a href="/sports/" data-nav="sports">Sports</a>
-      <a href="/companies/" data-nav="companies">Companies</a>
-      <a href="/targets/" data-nav="targets">Target Lists</a>
-      <a href="/nda/" data-nav="nda">NDA</a>
+      <a href="/scrape/" data-nav="scrape">Scraper</a>
+      <a href="/targets/" data-nav="targets">M&amp;A Target Lists</a>
+      <a href="/nda/" data-nav="nda">NDA Reviewer</a>
     </nav>
   </div></header>
 

--- a/public/css/brutalist.css
+++ b/public/css/brutalist.css
@@ -38,6 +38,10 @@ main{padding:var(--g4) 0}
 .card{grid-column:span 12;border:1px solid var(--border);padding:var(--g4);background:var(--bg)}
 .card h3{margin:0 0 var(--g2);font-size:20px}
 .card p{margin:0 0 var(--g3);font-size:14px;opacity:.85}
+.card-subheading{margin:var(--g3) 0 var(--g2);font-size:12px;letter-spacing:.08em;text-transform:uppercase;opacity:.65}
+.card-links{margin:0;padding:0;list-style:none;display:flex;flex-wrap:wrap;gap:var(--g2)}
+.card-links li{margin:0}
+.card-links a{font-weight:600;text-decoration:none;font-size:14px}
 @media (min-width: 720px){ .card{grid-column:span 6} }
 @media (min-width: 1000px){ .card{grid-column:span 4} }
 

--- a/public/index.html
+++ b/public/index.html
@@ -14,25 +14,36 @@
       <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">Menu</button>
       <nav id="primary-nav" class="site-nav" aria-label="Primary">
         <a href="/" data-nav="home">Home</a>
-        <a href="/scrape/" data-nav="scrape">Scrape</a>
-        <a href="/sports/" data-nav="sports">Sports</a>
-        <a href="/companies/" data-nav="companies">Companies</a>
-        <a href="/targets/" data-nav="targets">Target Lists</a>
-        <a href="/nda/" data-nav="nda">NDA</a>
+        <a href="/scrape/" data-nav="scrape">Scraper</a>
+        <a href="/targets/" data-nav="targets">M&amp;A Target Lists</a>
+        <a href="/nda/" data-nav="nda">NDA Reviewer</a>
       </nav>
     </div>
   </header>
 
   <main id="main" class="container">
     <h1>Tools</h1>
-    <p class="banner">Brutalist, fast, and consistent across the suite.</p>
 
     <section class="grid" aria-label="Tool grid">
-      <article class="card"><h3>New Scraper</h3><p>Bulk URL extraction with progress & exports.</p><a class="btn" href="/scrape/">Open Scraper</a></article>
-      <article class="card"><h3>Sports Scraper</h3><p>Preconfigured for sports stats (PFR/PBP-aware).</p><a class="btn" href="/sports/">Open Sports</a></article>
-      <article class="card"><h3>Company Scraper</h3><p>Directory/company‑centric extraction defaults.</p><a class="btn" href="/companies/">Open Companies</a></article>
-      <article class="card"><h3>Target List Processor</h3><p>Upload SourceScrub CSV → filter & export.</p><a class="btn" href="/targets/">Open Target Lists</a></article>
-      <article class="card"><h3>NDA Reviewer</h3><p>Analyze DOCX/paste → redlines & export.</p><a class="btn" href="/nda/">Open NDA Reviewer</a></article>
+      <article class="card">
+        <h3>M&amp;A Target List Builder</h3>
+        <a class="btn" href="/targets/">Open Target Lists</a>
+      </article>
+      <article class="card">
+        <h3>NDA Reviewer</h3>
+        <a class="btn" href="/nda/">Open NDA Reviewer</a>
+      </article>
+      <article class="card">
+        <h3>Scraper Suite</h3>
+        <a class="btn" href="/scrape/">Open Scraper</a>
+        <p class="card-subheading">Choose a mode</p>
+        <ul class="card-links">
+          <li><a href="/scrape/">General</a></li>
+          <li><a href="/scrape/app.html#news">News</a></li>
+          <li><a href="/sports/">Sports</a></li>
+          <li><a href="/companies/">Companies</a></li>
+        </ul>
+      </article>
     </section>
   </main>
 

--- a/public/js/nav.js
+++ b/public/js/nav.js
@@ -11,9 +11,7 @@
   function activeKey(path){
     path = normalizePath(path);
     if (path === '/') return 'home';
-    if (path.startsWith('/scrape')) return 'scrape';
-    if (path.startsWith('/sports')) return 'sports';
-    if (path.startsWith('/companies')) return 'companies';
+    if (path.startsWith('/scrape') || path.startsWith('/sports') || path.startsWith('/companies')) return 'scrape';
     if (path.startsWith('/targets')) return 'targets';
     if (path.startsWith('/nda')) return 'nda';
     return '';

--- a/public/nda/index.html
+++ b/public/nda/index.html
@@ -13,11 +13,9 @@
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">Menu</button>
     <nav id="primary-nav" class="site-nav" aria-label="Primary">
       <a href="/" data-nav="home">Home</a>
-      <a href="/scrape/" data-nav="scrape">Scrape</a>
-      <a href="/sports/" data-nav="sports">Sports</a>
-      <a href="/companies/" data-nav="companies">Companies</a>
-      <a href="/targets/" data-nav="targets">Target Lists</a>
-      <a href="/nda/" data-nav="nda">NDA</a>
+      <a href="/scrape/" data-nav="scrape">Scraper</a>
+      <a href="/targets/" data-nav="targets">M&amp;A Target Lists</a>
+      <a href="/nda/" data-nav="nda">NDA Reviewer</a>
     </nav>
   </div></header>
 

--- a/public/scrape/index.html
+++ b/public/scrape/index.html
@@ -12,11 +12,9 @@
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">Menu</button>
     <nav id="primary-nav" class="site-nav" aria-label="Primary">
       <a href="/" data-nav="home">Home</a>
-      <a href="/scrape/" data-nav="scrape">Scrape</a>
-      <a href="/sports/" data-nav="sports">Sports</a>
-      <a href="/companies/" data-nav="companies">Companies</a>
-      <a href="/targets/" data-nav="targets">Target Lists</a>
-      <a href="/nda/" data-nav="nda">NDA</a>
+      <a href="/scrape/" data-nav="scrape">Scraper</a>
+      <a href="/targets/" data-nav="targets">M&amp;A Target Lists</a>
+      <a href="/nda/" data-nav="nda">NDA Reviewer</a>
     </nav>
   </div></header>
 

--- a/public/sports/index.html
+++ b/public/sports/index.html
@@ -12,11 +12,9 @@
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">Menu</button>
     <nav id="primary-nav" class="site-nav" aria-label="Primary">
       <a href="/" data-nav="home">Home</a>
-      <a href="/scrape/" data-nav="scrape">Scrape</a>
-      <a href="/sports/" data-nav="sports">Sports</a>
-      <a href="/companies/" data-nav="companies">Companies</a>
-      <a href="/targets/" data-nav="targets">Target Lists</a>
-      <a href="/nda/" data-nav="nda">NDA</a>
+      <a href="/scrape/" data-nav="scrape">Scraper</a>
+      <a href="/targets/" data-nav="targets">M&amp;A Target Lists</a>
+      <a href="/nda/" data-nav="nda">NDA Reviewer</a>
     </nav>
   </div></header>
 

--- a/public/targets/index.html
+++ b/public/targets/index.html
@@ -13,11 +13,9 @@
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-nav">Menu</button>
     <nav id="primary-nav" class="site-nav" aria-label="Primary">
       <a href="/" data-nav="home">Home</a>
-      <a href="/scrape/" data-nav="scrape">Scrape</a>
-      <a href="/sports/" data-nav="sports">Sports</a>
-      <a href="/companies/" data-nav="companies">Companies</a>
-      <a href="/targets/" data-nav="targets">Target Lists</a>
-      <a href="/nda/" data-nav="nda">NDA</a>
+      <a href="/scrape/" data-nav="scrape">Scraper</a>
+      <a href="/targets/" data-nav="targets">M&amp;A Target Lists</a>
+      <a href="/nda/" data-nav="nda">NDA Reviewer</a>
     </nav>
   </div></header>
 


### PR DESCRIPTION
## Summary
- Reordered the home page cards to highlight the M&A Target List Builder, NDA Reviewer, and consolidated Scraper suite options.
- Added inline links and supporting styles for selecting General, News, Sports, or Companies modes from the unified Scraper card.
- Simplified the primary navigation across all tool pages to focus on Scraper, M&A Target Lists, and the NDA Reviewer, updating the nav script accordingly.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5ff11a954832bbfb79e64b062ca46